### PR TITLE
fix: 解决mac环境下因python版本导致的打包失败问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
   "gitHooks": {
     "pre-commit": "lint-staged"
   },
+  "resolutions": {
+    "vue-cli-plugin-electron-builder/electron-builder": "^23.0.3"
+  },
   "keywords": [
     "electron",
     "vue",

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -22,7 +22,7 @@ export const antdMessages: { [key: string]: any} = {
 /**
  * 框架 多语言 配置
  */
-export const messages = importAllLocales();
+export const messages = importAllLocales() as any;
 const sysLocale = getLocale();
 const i18n = createI18n({
     legacy: false,


### PR DESCRIPTION
1. Fix Error: Exit code: ENOENT. spawn /usr/bin/python ENOENT

报错日志：`Error: Exit code: ENOENT. spawn /usr/bin/python ENOENT`

报错原因：由于mac系统升级后默认python命令是指向python3的，但是vue-cli-plugin-electron-builder是要求python2的，但是electron-builder是支持的，所以指定其使用electron-builder v23.0.3版本。

2. Fix Error: config/i18n.ts文件中类型拼写检查导致的报错问题；
